### PR TITLE
Add SSL pinning bypass script for Instagram v421

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Android Instagram SSL Pinning Bypass
 
-**📆 Update:** As of **December 12, 2025**, JavaScript files for bypassing SSL pinning in the Instagram Android APK v409 have been successfully tested and are shared here free of charge. 🧪
+**📆 Update:** As of **March 19, 2026**, JavaScript files for bypassing SSL pinning in the Instagram Android APK v421 have been successfully tested and are shared here free of charge. 🧪
 
 ![Instagram Android SSL Pinning Bypass](https://i.imgur.com/rwqsXb2.jpeg) 
 ---
@@ -9,7 +9,7 @@
 - **Rooted Android Emulator** (e.g., Nox Player with root mode enabled) 📱  
 - **Frida** installed on your computer 🖥️  
 - Matching **frida-server** binary running inside the emulator (same version as host Frida)  
-- Instagram **APK** (v395 - v409) installed in the emulator  
+- Instagram **APK** (v395 - v421) installed in the emulator  
 
 ---
 
@@ -20,6 +20,7 @@
 - Download correct APK version for v398 [[v398](https://www.apkmirror.com/apk/instagram/instagram-instagram/instagram-398-1-0-53-77-release/instagram-398-1-0-53-77-7-android-apk-download/)]
 - Download correct APK version for v399 [[v399](https://www.apkmirror.com/apk/instagram/instagram-instagram/instagram-399-0-0-51-85-release/instagram-399-0-0-51-85-5-android-apk-download/)]
 - Download correct APK version for v409 [[v409](https://www.apkmirror.com/apk/instagram/instagram-instagram/instagram-409-0-0-48-170-release/instagram-409-0-0-48-170-2-android-apk-download/)]
+- Download correct APK version for v421 [[v421](https://www.apkmirror.com/apk/instagram/instagram-instagram/instagram-421-0-0-34-71-release/)]
 ---
 
 ## Quick Start 🚀
@@ -48,6 +49,7 @@ set "SCRIPT=C:\Users\PCName\Desktop\TheScriptThatYouDownloaded.js"
 - v398 → https://codeshare.frida.re/@takaotr/instagram-ssl-pinning-bypass-v398/
 - v399 → https://codeshare.frida.re/@takaotr/instagram-ssl-pinning-bypass-v399/
 - v409 → https://codeshare.frida.re/@takaotr/instagram-ssl-pinning-bypass-v409/
+- v421 → https://codeshare.frida.re/@takaotr/instagram-ssl-pinning-bypass-v421/
   
 ---
 

--- a/TAKAO-InstagramSSLPinningBypass-v421.js
+++ b/TAKAO-InstagramSSLPinningBypass-v421.js
@@ -1,0 +1,98 @@
+/* UPDATED FOR INSTAGRAM v421
+Original base by TAKAO TR */
+
+'use strict'
+
+var isTigonMNSServiceHolderHooked = false;
+
+function hookLibLoading() {
+    Java.perform(() => {
+        const SoLoader = Java.use("com.facebook.soloader.MergedSoMapping$Invoke_JNI_OnLoad");
+
+        // We hook libappstatelogger2 as a trigger point for Tigon loading
+        const targetLib = SoLoader.libappstatelogger2_so || SoLoader.libtigon_so;
+
+        if (targetLib) {
+            targetLib.implementation = function() {
+                if (!isTigonMNSServiceHolderHooked) {
+                    isTigonMNSServiceHolderHooked = true;
+                    hookTigonMNSServiceHolder();
+                }
+                return targetLib.call(this);
+            };
+        } else {
+            // Fallback: If loader hook fails, try immediate hook
+            hookTigonMNSServiceHolder();
+        }
+    });
+}
+
+function hookTigonMNSServiceHolder() {
+    Java.perform(() => {
+        try {
+            const Holder = Java.use("com.facebook.tigon.tigonmns.TigonMNSServiceHolder");
+
+            // Hook EVERY overload of initHybrid to be safe for v421
+            Holder.initHybrid.overloads.forEach((ol) => {
+                ol.implementation = function() {
+                    const cfg = arguments[0]; // TigonMNSConfig is always first
+
+                    if (cfg) {
+                        const cfgClass = cfg.$className;
+                        console.log(`[*][+] Patching Config in initHybrid: ${cfgClass}`);
+
+                        // Disable Cert Verification
+                        try {
+                            if (cfg.setEnableCertificateVerificationWithProofOfPossession)
+                                cfg.setEnableCertificateVerificationWithProofOfPossession(false);
+                            if (cfg.setVerifyCertificates)
+                                cfg.setVerifyCertificates(false);
+                        } catch (e) {}
+
+                        // Enable Sandbox/Proxy Trust
+                        try {
+                            if (cfg.setTrustSandboxCertificates)
+                                cfg.setTrustSandboxCertificates(true);
+                        } catch (e) {}
+                    }
+
+                    return ol.apply(this, arguments);
+                };
+            });
+            console.log("[*][+] Successfully applied multi-overload hook to Tigon");
+        } catch (e) {
+            console.log("[*][-] Tigon Hook Error: " + e);
+        }
+    });
+}
+
+// Standard Conscrypt/TrustManager Bypass
+Java.perform(function() {
+    try {
+        const TrustManagerImpl = Java.use('com.android.org.conscrypt.TrustManagerImpl');
+        const ArrayList = Java.use("java.util.ArrayList");
+
+        // Hook checkTrustedRecursive
+        if (TrustManagerImpl.checkTrustedRecursive) {
+            TrustManagerImpl.checkTrustedRecursive.implementation = function(chain, host, flags, a4, a5, a6) {
+                console.log(`[*][+] Bypassing TrustManagerImpl for: ${host}`);
+                return ArrayList.$new(); // Return empty list to signify trust
+            }
+        }
+    } catch (e) {
+        console.log("[*][-] Conscrypt Hook Failed");
+    }
+
+    // Generic SSLContext Hook
+    try {
+        const SSLContext = Java.use("javax.net.ssl.SSLContext");
+        SSLContext.init.overload("[Ljavax.net.ssl.KeyManager;", "[Ljavax.net.ssl.TrustManager;", "java.security.SecureRandom").implementation = function(km, tm, sr) {
+            console.log("[*][+] Redirecting SSLContext.init to null TrustManager");
+            return this.init(km, null, sr);
+        };
+    } catch (e) {
+        console.log("[*][-] SSLContext Hook Failed");
+    }
+});
+
+hookLibLoading();


### PR DESCRIPTION
- Hooks all initHybrid overloads for broader v421 compatibility
- Falls back to libtigon_so if libappstatelogger2_so is unavailable
- Disables cert verification and enables sandbox/proxy trust
- Includes Conscrypt TrustManagerImpl and SSLContext bypasses
